### PR TITLE
add longhorn host prereqs + nfs backup target on nas

### DIFF
--- a/nixos/arch-hardware-configuration.nix
+++ b/nixos/arch-hardware-configuration.nix
@@ -102,6 +102,18 @@ in {
     fsType = "ext4";
   };
 
+  # Longhorn replica disk for the k3s cluster. The LV (pool1/longhorn, 700G)
+  # was created manually inside the existing pool1 LUKS volume. Bring up the
+  # filesystem on first deploy with:
+  #   sudo mkfs.ext4 -L longhorn /dev/mapper/pool1-longhorn
+  #   sudo install -d -m 0755 -o root -g root /mnt/longhorn
+  # `nofail` keeps the box bootable if the LV is ever absent.
+  fileSystems."/mnt/longhorn" = {
+    device = "/dev/disk/by-label/longhorn";
+    fsType = "ext4";
+    options = ["defaults" "noatime" "nofail"];
+  };
+
   #fileSystems."/mnt/games_b" = {
   #device = "/dev/pool1a/games_b";
   #fsType = "ext4";

--- a/nixos/modules/k3s-agent.nix
+++ b/nixos/modules/k3s-agent.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: {
   options.custom.k3sNodeTaints = lib.mkOption {
@@ -24,5 +25,41 @@
       serverAddr = "https://192.168.5.35:6443";
       tokenFile = config.age.secrets.k3s-local-token.path;
     };
+
+    # === Longhorn host prerequisites ===
+    #
+    # Longhorn is a CSI driver whose manager pod nsenter()s into the host
+    # PID namespace and shells out to fixed-path binaries (iscsiadm, mount,
+    # nsenter, findmnt, mkfs.ext4, lsblk). On NixOS those binaries live
+    # under /run/current-system/sw/bin, not /usr/bin or /usr/local/sbin
+    # where Longhorn looks. Three pieces:
+    #   1. enable iscsid (Longhorn uses iSCSI as its block transport),
+    #   2. install the host-side packages so they exist in the system PATH,
+    #   3. symlink the specific paths Longhorn hardcodes.
+    # Reference pattern: github.com/duckfullstop/nixos-longhorn.
+    services.openiscsi = {
+      enable = true;
+      name = "iqn.2026-05.me.2143:${config.networking.hostName}";
+    };
+
+    environment.systemPackages = with pkgs; [
+      openiscsi
+      nfs-utils
+      util-linux
+      e2fsprogs
+      xfsprogs
+      cryptsetup
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d /var/lib/longhorn 0755 root root - -"
+      "L+ /usr/local/sbin/iscsiadm  - - - - ${pkgs.openiscsi}/bin/iscsiadm"
+      "L+ /usr/local/bin/mount      - - - - ${pkgs.util-linux}/bin/mount"
+      "L+ /usr/local/bin/umount     - - - - ${pkgs.util-linux}/bin/umount"
+      "L+ /usr/local/bin/findmnt    - - - - ${pkgs.util-linux}/bin/findmnt"
+      "L+ /usr/local/bin/nsenter    - - - - ${pkgs.util-linux}/bin/nsenter"
+      "L+ /usr/local/bin/lsblk      - - - - ${pkgs.util-linux}/bin/lsblk"
+      "L+ /usr/local/sbin/mkfs.ext4 - - - - ${pkgs.e2fsprogs}/bin/mkfs.ext4"
+    ];
   };
 }

--- a/nixos/nas-configuration.nix
+++ b/nixos/nas-configuration.nix
@@ -254,6 +254,13 @@
         daily = 0;
         monthly = 0;
       };
+      # k8s Longhorn backup target. Long retention because this is the
+      # disaster-recovery layer for cluster PVCs.
+      "tank/longhorn-backups" = {
+        autosnap = true;
+        daily = 30;
+        monthly = 12;
+      };
     };
   };
 
@@ -329,6 +336,32 @@
   };
 
   # ================
+  # === NFS      ===
+  # ================
+  #
+  # NFSv4 export used SOLELY as a Longhorn backup target for the k3s cluster.
+  # No live PVCs sit on this — Longhorn replicates volume data on cluster
+  # NVMe (closet + arch) and pushes incremental backups here on a schedule.
+  # If this NFS server is unreachable, only new backup uploads pause; live
+  # cluster workloads are unaffected.
+  #
+  # One-time on the NAS before the first rebuild that flips this on:
+  #   sudo zfs create -o mountpoint=/tank/longhorn-backups -o recordsize=1M \
+  #     -o compression=lz4 -o atime=off tank/longhorn-backups
+  #   sudo chown nobody:nogroup /tank/longhorn-backups
+  #   sudo chmod 0777 /tank/longhorn-backups
+  #
+  # The export is scoped to the Tailscale CGNAT range, matching the Samba
+  # `hosts allow` line above. Single port (2049) — NFSv4 doesn't need
+  # rpcbind/mountd/lockd.
+  services.nfs.server = {
+    enable = true;
+    exports = ''
+      /tank/longhorn-backups 100.64.0.0/10(rw,sync,no_subtree_check,no_root_squash,fsid=0)
+    '';
+  };
+
+  # ================
   # === Immich   ===
   # ================
 
@@ -397,6 +430,7 @@
   networking.firewall = {
     #enable = true;
     allowedTCPPorts = [
+      2049 # nfsv4 (Longhorn backup target)
       2283 # immich
       25565 # minecraft
     ];


### PR DESCRIPTION
- nas: nfsv4 export of /tank/longhorn-backups for the cluster's longhorn
  backup target (sanoid daily/monthly retention added). live cluster I/O
  never depends on this — backup-only.
- k3s-agent module: enable openiscsi, install host-side packages, and
  symlink the binaries longhorn hardcodes (/usr/local/{s,}bin/{iscsiadm,
  mount,umount,findmnt,nsenter,lsblk,mkfs.ext4}).
- arch: declare /mnt/longhorn fileSystem on the new pool1/longhorn LV
  (700G inside the existing pool1 LUKS). nofail so a missing LV doesn't
  block boot. mkfs.ext4 -L longhorn happens once at first deploy.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
